### PR TITLE
Forgot password functionality

### DIFF
--- a/Backend/.vscode/launch.json
+++ b/Backend/.vscode/launch.json
@@ -16,7 +16,7 @@
                 "args": "${auto-detect-url}"
             },
             "env": {
-                "ASPNETCORE_URLS": "http://192.168.1.47:5000",
+                "ASPNETCORE_URLS": "http://192.168.22.39:5000",
             },
             "justMyCode": true
         }

--- a/Backend/.vscode/launch.json
+++ b/Backend/.vscode/launch.json
@@ -16,7 +16,7 @@
                 "args": "${auto-detect-url}"
             },
             "env": {
-                "ASPNETCORE_URLS": "http://192.168.22.39:5000",
+                "ASPNETCORE_URLS": "http://192.168.1.47:5000",
             },
             "justMyCode": true
         }

--- a/Backend/Backend/Controllers/AuthController.cs
+++ b/Backend/Backend/Controllers/AuthController.cs
@@ -110,6 +110,16 @@ namespace Backend.Controllers
         }
 
         [AllowAnonymous]
+        [ProducesResponseType(200, Type = typeof(ApiResponse))]
+        [HttpPost("reset")]
+        public async Task<IActionResult> ForgotPassword([FromBody] ResetPasswordRequest model)
+        {
+            var apiResponse = await _authService.ResetPassword(model);
+
+            return Ok(apiResponse);
+        }
+
+        [AllowAnonymous]
         [HttpGet("redirect")]
         public async Task<IActionResult> RedirectToCustomScheme([FromQuery] string redirect)
         {

--- a/Backend/Backend/Controllers/AuthController.cs
+++ b/Backend/Backend/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using Backend.Models.Dto;
 using Backend.Service.Interface;
 using Backend.Utility;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Backend.Controllers
@@ -97,6 +98,32 @@ namespace Backend.Controllers
         {
             var apiResponse = await _authService.ChangePassword(model);
             return StatusCode((int)apiResponse.StatusCode, apiResponse);
+        }
+
+        [AllowAnonymous]
+        [HttpPost("forgot")]
+        public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordRequest model)
+        {
+            await _authService.ForgotPassword(model);
+
+            return Ok("Email sent with a reset link");
+        }
+
+        [AllowAnonymous]
+        [HttpGet("redirect")]
+        public async Task<IActionResult> RedirectToCustomScheme([FromQuery] string redirect)
+        {
+            if (string.IsNullOrWhiteSpace(redirect))
+            {
+                return BadRequest("Invalid redirect URL.");
+            }
+
+            if (!redirect.Contains("soppro://"))
+            {
+                return BadRequest("Invalid redirect scheme.");
+            }
+
+            return Redirect(redirect);
         }
     }
 }

--- a/Backend/Backend/Models/Settings/ApplicationSettings.cs
+++ b/Backend/Backend/Models/Settings/ApplicationSettings.cs
@@ -2,6 +2,7 @@
 {
     public class ApplicationSettings
     {
+        public string BaseUrl { get; set; }
         public string JwtSecret { get; set; }
         public string JwtIssuer { get; set; }
         public string JwtAudience { get; set; }

--- a/Backend/Backend/Program.cs
+++ b/Backend/Backend/Program.cs
@@ -25,7 +25,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
 }, ServiceLifetime.Scoped);
 builder.Services.AddSingleton(u => new BlobServiceClient(builder.Configuration.GetConnectionString("AzureBlobStorage")));
-builder.Services.AddIdentity<ApplicationUser, IdentityRole>().AddEntityFrameworkStores<ApplicationDbContext>();
+builder.Services.AddIdentity<ApplicationUser, IdentityRole>().AddEntityFrameworkStores<ApplicationDbContext>().AddDefaultTokenProviders();
 builder.Services.Configure<IdentityOptions>(options =>
 {
     // Default Password settings.

--- a/Backend/Backend/Service/Implementation/AuthService.cs
+++ b/Backend/Backend/Service/Implementation/AuthService.cs
@@ -341,8 +341,12 @@ namespace Backend.Service.Implementation
             if (user != null)
             {
                 var token = await _userManager.GeneratePasswordResetTokenAsync(user);
-                var resetUrl = $"soppro://reset?email={model.Email}&token={HttpUtility.UrlEncode(token)}";
-                await _emailService.SendEmailAsync(model.Email, "test", $@"<a href=""http://192.168.1.47:5000/api/auth/redirect?redirect={resetUrl}"">Click here to reset your password</a>");
+                var encodedToken = Uri.EscapeDataString(token);
+
+                var resetUrl = $"soppro://reset?email={model.Email}&token={encodedToken}";
+                var redirectUrl = $"http://192.168.1.47:5000/api/auth/redirect?redirect={Uri.EscapeDataString(resetUrl)}";
+
+                await _emailService.SendEmailAsync(model.Email, "Password Reset", $@"<a href=""{redirectUrl}"">Click here to reset your password</a>");
             }
         }
 

--- a/Backend/Backend/Service/Implementation/AuthService.cs
+++ b/Backend/Backend/Service/Implementation/AuthService.cs
@@ -346,6 +346,33 @@ namespace Backend.Service.Implementation
             }
         }
 
+        public async Task<ApiResponse> ResetPassword(ResetPasswordRequest model)
+        {
+            if (!ValidatePassword(model.NewPassword))
+            {
+                throw new Exception("Password does not meet requirements");
+            }
+
+            var user = await _userManager.FindByEmailAsync(model.Email);
+            if (user == null)
+            {
+                throw new Exception("User could not be found");
+            }
+
+            var result = await _userManager.ResetPasswordAsync(user, model.ResetCode, model.NewPassword);
+            if (!result.Succeeded)
+            {
+                throw new Exception("Error reseting password");
+            }
+
+            return new ApiResponse()
+            {
+                IsSuccess = true,
+                SuccessMessage = "Password reset successfully",
+                StatusCode = HttpStatusCode.OK
+            };
+        }
+
         public bool ValidatePassword(string password)
         {
             // Check if the password length is sufficient

--- a/Backend/Backend/Service/Implementation/AuthService.cs
+++ b/Backend/Backend/Service/Implementation/AuthService.cs
@@ -7,16 +7,12 @@ using Backend.Models.Tenancy;
 using Backend.Repository.Interface;
 using Backend.Service.Interface;
 using Backend.Utility;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Security.Claims;
-using System.Web;
 
 namespace Backend.Service.Implementation
 {
@@ -344,7 +340,7 @@ namespace Backend.Service.Implementation
                 var encodedToken = Uri.EscapeDataString(token);
 
                 var resetUrl = $"soppro://reset?email={model.Email}&token={encodedToken}";
-                var redirectUrl = $"http://192.168.1.47:5000/api/auth/redirect?redirect={Uri.EscapeDataString(resetUrl)}";
+                var redirectUrl = $"{_appSettings.BaseUrl}/api/auth/redirect?redirect={Uri.EscapeDataString(resetUrl)}";
 
                 await _emailService.SendEmailAsync(model.Email, "Password Reset", $@"<a href=""{redirectUrl}"">Click here to reset your password</a>");
             }

--- a/Backend/Backend/Service/Interface/IAuthService.cs
+++ b/Backend/Backend/Service/Interface/IAuthService.cs
@@ -13,5 +13,6 @@ namespace Backend.Service.Interface
         Task<ApiResponse<LoginResponseDTO>> Login(LoginRequestDTO model, ModelStateDictionary modelState);
         Task<ApiResponse> ChangePassword(ChangePasswordDto model);
         Task ForgotPassword(ForgotPasswordRequest model);
+        Task<ApiResponse> ResetPassword(ResetPasswordRequest model);
     }
 }

--- a/Backend/Backend/Service/Interface/IAuthService.cs
+++ b/Backend/Backend/Service/Interface/IAuthService.cs
@@ -1,5 +1,6 @@
 ﻿using Backend.Models;
 using Backend.Models.Dto;
+using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Backend.Service.Interface
@@ -11,5 +12,6 @@ namespace Backend.Service.Interface
         Task<ApiResponse> SignupOrganisation(OrganisationSignupRequest model, ModelStateDictionary modelState);
         Task<ApiResponse<LoginResponseDTO>> Login(LoginRequestDTO model, ModelStateDictionary modelState);
         Task<ApiResponse> ChangePassword(ChangePasswordDto model);
+        Task ForgotPassword(ForgotPasswordRequest model);
     }
 }

--- a/SopPro/app/(auth)/_layout.jsx
+++ b/SopPro/app/(auth)/_layout.jsx
@@ -10,8 +10,7 @@ import { authActions } from "../../store/authSlice";
 
 import { Stack, Redirect } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import { FontAwesome5 } from "@expo/vector-icons";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { ActivityIndicator } from "react-native-paper";
 
 export {

--- a/SopPro/app/(auth)/user/changePassword.jsx
+++ b/SopPro/app/(auth)/user/changePassword.jsx
@@ -1,4 +1,4 @@
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScrollView, StyleSheet, Text } from "react-native";
 import React, { useState } from "react";
 import { Button, TextInput } from "react-native-paper";
 import Toast from "react-native-toast-message";

--- a/SopPro/app/_layout.jsx
+++ b/SopPro/app/_layout.jsx
@@ -67,6 +67,8 @@ function RootLayoutNav() {
         <Stack.Screen name="home" options={{ headerShown: false }} />
         <Stack.Screen name="login" options={{ title: "Log in" }} />
         <Stack.Screen name="register" options={{ title: "Sign up " }} />
+        <Stack.Screen name="forgot" options={{ title: "Forgot password " }} />
+        <Stack.Screen name="reset" options={{ title: "Reset password " }} />
       </Stack>
     </>
   );

--- a/SopPro/app/forgot.jsx
+++ b/SopPro/app/forgot.jsx
@@ -1,0 +1,87 @@
+import { StyleSheet, Text, View } from "react-native";
+import React, { useState } from "react";
+import { ScrollView } from "react-native-gesture-handler";
+import Header from "../components/UI/Header";
+import { Button, TextInput } from "react-native-paper";
+import { validateEmail } from "../util/validationHelpers";
+import InputErrorMessage from "../components/UI/InputErrorMessage";
+import { forgotPassword } from "../util/httpRequests";
+import { useMutation } from "@tanstack/react-query";
+import Toast from "react-native-toast-message";
+
+const forgot = () => {
+  const [email, setEmail] = useState("");
+  const [emailError, setEmailError] = useState(false);
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: forgotPassword,
+    onSuccess: () => {
+      Toast.show({
+        type: "success",
+        text1: "Reset Email link sent",
+        visibilityTime: 3000,
+      });
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
+  function handlePress() {
+    setEmailError(false);
+
+    const emailValidator = validateEmail(email);
+    if (!emailValidator.isFieldValid) {
+      setEmailError(emailValidator.message);
+      return;
+    }
+
+    mutate(email);
+  }
+  return (
+    <ScrollView style={styles.rootContainer}>
+      <View style={styles.formContainer}>
+        <Header text="Reset password" textStyle={{ color: "black" }} />
+        <TextInput
+          style={styles.textInput}
+          error={emailError !== false}
+          label="Email"
+          keyboardType="email-address"
+          value={email}
+          onChangeText={(value) => setEmail(value)}
+        />
+        {emailError !== false && (
+          <InputErrorMessage>{emailError}</InputErrorMessage>
+        )}
+        <Button
+          mode="contained"
+          loading={isPending}
+          contentStyle={{ height: 50 }}
+          labelStyle={{ fontSize: 20 }}
+          style={styles.buttonContainer}
+          onPress={handlePress}
+        >
+          Reset Password
+        </Button>
+      </View>
+    </ScrollView>
+  );
+};
+
+export default forgot;
+
+const styles = StyleSheet.create({
+  rootContainer: {
+    flex: 1,
+    margin: 30,
+    paddingTop: 50,
+  },
+  formContainer: {},
+  textInput: {
+    marginVertical: 2,
+  },
+  buttonContainer: {
+    borderRadius: 0,
+    marginVertical: 14,
+  },
+});

--- a/SopPro/app/forgot.jsx
+++ b/SopPro/app/forgot.jsx
@@ -23,7 +23,11 @@ const forgot = () => {
       });
     },
     onError: (error) => {
-      console.log(error);
+      Toast.show({
+        type: "error",
+        text1: error.message,
+        visibilityTime: 3000,
+      });
     },
   });
 

--- a/SopPro/app/reset.jsx
+++ b/SopPro/app/reset.jsx
@@ -1,0 +1,14 @@
+import { StyleSheet, Text, View } from "react-native";
+import React from "react";
+
+const reset = () => {
+  return (
+    <View>
+      <Text>reset</Text>
+    </View>
+  );
+};
+
+export default reset;
+
+const styles = StyleSheet.create({});

--- a/SopPro/app/reset.jsx
+++ b/SopPro/app/reset.jsx
@@ -1,18 +1,92 @@
 import { StyleSheet, Text, View } from "react-native";
 import { useLocalSearchParams } from "expo-router";
-import React from "react";
+import React, { useState } from "react";
+import { Button, TextInput } from "react-native-paper";
+import { useMutation } from "@tanstack/react-query";
+import { resetPassword } from "../util/httpRequests";
+import { validatePassword } from "../util/validationHelpers";
+import InputErrorMessage from "../components/UI/InputErrorMessage";
+import Toast from "react-native-toast-message";
 
 const reset = () => {
   const { token, email } = useLocalSearchParams();
-  console.log(token, email);
+  const [password, setPassword] = useState("");
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [passwordError, setPasswordError] = useState(false);
+
+  const formattedToken = token.replace(/ /g, "+");
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: resetPassword,
+    onSuccess: () => {
+      Toast.show({
+        type: "success",
+        text1: "Password reset",
+        visibilityTime: 3000,
+      });
+    },
+    onError: (error) => {
+      Toast.show({
+        type: "error",
+        text1: error.message,
+        visibilityTime: 3000,
+      });
+    },
+  });
+
+  function handlePress() {
+    setPasswordError(false);
+    const passwordValidator = validatePassword(password);
+    if (!passwordValidator.isFieldValid) {
+      setPasswordError(passwordValidator.message);
+      return;
+    }
+
+    mutate({ email, formattedToken, password });
+  }
+
   return (
-    <View>
-      <Text>{token}</Text>
-      <Text>{email}</Text>
+    <View style={styles.rootContainer}>
+      <TextInput
+        label="New Password"
+        error={passwordError !== false}
+        value={password}
+        onChangeText={(value) => setPassword(value)}
+        secureTextEntry={!isPasswordVisible}
+        right={
+          <TextInput.Icon
+            icon={isPasswordVisible ? "eye-off" : "eye"}
+            onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+          />
+        }
+      />
+      {passwordError !== false && (
+        <InputErrorMessage>{passwordError}</InputErrorMessage>
+      )}
+      <Button
+        mode="contained"
+        loading={isPending}
+        contentStyle={{ height: 50 }}
+        labelStyle={{ fontSize: 20 }}
+        style={styles.buttonContainer}
+        onPress={handlePress}
+      >
+        Reset Password
+      </Button>
     </View>
   );
 };
 
 export default reset;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  rootContainer: {
+    flex: 1,
+    margin: 30,
+    paddingTop: 50,
+  },
+  buttonContainer: {
+    borderRadius: 0,
+    marginVertical: 14,
+  },
+});

--- a/SopPro/app/reset.jsx
+++ b/SopPro/app/reset.jsx
@@ -1,10 +1,14 @@
 import { StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
 import React from "react";
 
 const reset = () => {
+  const { token, email } = useLocalSearchParams();
+  console.log(token, email);
   return (
     <View>
-      <Text>reset</Text>
+      <Text>{token}</Text>
+      <Text>{email}</Text>
     </View>
   );
 };

--- a/SopPro/components/login/LoginForm.jsx
+++ b/SopPro/components/login/LoginForm.jsx
@@ -61,7 +61,11 @@ const LoginForm = ({ onSubmit, isPending }) => {
           {isPending ? "Loggin in..." : "Log in"}
         </Button>
       </View>
-      <Button mode="text" onPress={handleForgotPasswordPress}>
+      <Button
+        style={{ marginVertical: 8 }}
+        mode="text"
+        onPress={handleForgotPasswordPress}
+      >
         Forgot Password
       </Button>
     </>

--- a/SopPro/components/login/LoginForm.jsx
+++ b/SopPro/components/login/LoginForm.jsx
@@ -2,14 +2,21 @@ import React, { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { TextInput, Button } from "react-native-paper";
 import Header from "../UI/Header";
+import { useRouter } from "expo-router";
 
 const LoginForm = ({ onSubmit, isPending }) => {
+  const router = useRouter();
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   function handlePress() {
     onSubmit({ email, password });
+  }
+
+  function handleForgotPasswordPress() {
+    router.navigate("forgot");
   }
 
   return (
@@ -54,6 +61,9 @@ const LoginForm = ({ onSubmit, isPending }) => {
           {isPending ? "Loggin in..." : "Log in"}
         </Button>
       </View>
+      <Button mode="text" onPress={handleForgotPasswordPress}>
+        Forgot Password
+      </Button>
     </>
   );
 };

--- a/SopPro/util/httpRequests.js
+++ b/SopPro/util/httpRequests.js
@@ -219,3 +219,18 @@ export async function changePasswordRequest({
     throw error;
   }
 }
+
+export async function forgotPassword(email) {
+  try {
+    const response = await api.post("/auth/forgot", {
+      email,
+    });
+
+    return response.data;
+  } catch (e) {
+    const error = new Error(
+      e.response?.data?.errorMessage || "Error requesting reset"
+    );
+    throw error;
+  }
+}

--- a/SopPro/util/httpRequests.js
+++ b/SopPro/util/httpRequests.js
@@ -234,3 +234,17 @@ export async function forgotPassword(email) {
     throw error;
   }
 }
+
+export async function resetPassword({ email, formattedToken, password }) {
+  const data = { email, resetCode: formattedToken, newPassword: password };
+
+  try {
+    const response = await api.post("/auth/reset", data);
+    return response.data;
+  } catch (e) {
+    const error = new Error(
+      e.response?.data?.errorMessage || "Error reseting password"
+    );
+    throw error;
+  }
+}


### PR DESCRIPTION
### Summary
- Added forgot password endpoint
- Added forgot password screen
- Added reset password endpoint
- Added reset password screen
- Added validation checks for email/new password
- Added deep linking support for reset email URL, which opens the app on the reset password page and passes the token/email
- Added redirect endpoint to support deep linking (without this url's that are formatted for deep linking do not appear correctly in emails).

<img width="376" alt="Screenshot 2025-02-07 at 20 51 50" src="https://github.com/user-attachments/assets/fdbb308d-1f01-48d4-921d-5b486321c9bf" />
<img width="376" alt="Screenshot 2025-02-07 at 20 52 08" src="https://github.com/user-attachments/assets/16249184-2f10-46a8-917d-35a5d9a88d45" />
