### PR TITLE
Feature - Revert to a specific version

### DIFF
--- a/Backend/Backend/Controllers/SopController.cs
+++ b/Backend/Backend/Controllers/SopController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Backend.Utility;
 using Microsoft.SemanticKernel.ChatCompletion;
+using System.Net;
 
 namespace Backend.Controllers
 {
@@ -152,6 +153,25 @@ namespace Backend.Controllers
         {
             var analyticsDto = await _sopService.GetAnalytics();
             return Ok(analyticsDto);
+        }
+
+        [HttpPost]
+        [Route("revert")]
+        [Authorize(Roles = StaticDetails.Role_Admin)]
+        [ProducesResponseType(200, Type = typeof(ApiResponse))]
+        public async Task<IActionResult> RevertSopVersion([FromBody] RevertRequestDto model)
+        {
+
+            await _sopService.RevertSop(model);
+            ApiResponse response = new ApiResponse()
+            {
+                IsSuccess = true,
+                StatusCode = HttpStatusCode.OK,
+                SuccessMessage = "Version reverted successfully"
+            }
+            ;
+
+            return Ok(response);
         }
 
     }

--- a/Backend/Backend/Models/Dto/RevertRequestDto.cs
+++ b/Backend/Backend/Models/Dto/RevertRequestDto.cs
@@ -1,0 +1,7 @@
+namespace Backend.Models.Dto
+{
+    public class RevertRequestDto
+    {
+        public int versionId { get; set; }
+    }
+}

--- a/Backend/Backend/Service/Implementation/PdfService.cs
+++ b/Backend/Backend/Service/Implementation/PdfService.cs
@@ -62,7 +62,7 @@ namespace Backend.Service.Implementation
 
             string emailBody = await _templateService.RenderTemplateAsync("PdfExport", emailTemplateModel);
             string pdfName = "SOP" + "-" + sop.Reference + "-V" + model.Version + "-" + DateTime.UtcNow.ToString("dd/MM/yyyy HH:mm");
-            _emailService.SendEmailWithPdfAttachmentAsync(recipients, null, "Exported sop is ready", emailBody, template, pdfName);
+            // _emailService.SendEmailWithPdfAttachmentAsync(recipients, null, "Exported sop is ready", emailBody, template, pdfName);
 
             return template;
         }

--- a/Backend/Backend/Service/Interface/ISopService.cs
+++ b/Backend/Backend/Service/Interface/ISopService.cs
@@ -20,6 +20,7 @@ namespace Backend.Service.Interface
         public Task<SopVersionDto> GetSopVersion(int sopVersionId);
         public Task<SopDto> GenerateAiSop(AiRequestDto model);
         public Task<AnalyticsResponseDto> GetAnalytics();
+        public Task RevertSop(RevertRequestDto model);
 
     };
 }

--- a/SopPro/app/(auth)/(tabs)/index.jsx
+++ b/SopPro/app/(auth)/(tabs)/index.jsx
@@ -1,4 +1,4 @@
-import { FlatList, ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScrollView, StyleSheet } from "react-native";
 import Fab from "../../../components/sops/fab";
 import { useIsFocused } from "@react-navigation/native";
 import { useSelector } from "react-redux";
@@ -6,8 +6,6 @@ import Header from "../../../components/UI/Header";
 import { capitiliseFirstLetter } from "../../../util/validationHelpers";
 import { fetchSops } from "../../../util/httpRequests";
 import { useQuery } from "@tanstack/react-query";
-import SopCardLarge from "../../../components/sops/SopCardLarge";
-import SopCardLargeSkeleton from "../../../components/skeletons/SopCardLargeSkeleton";
 import CustomBottomSheetModal from "../../../components/sops/bottomSheet/CustomBottomSheetModal";
 import { useCallback, useRef, useState } from "react";
 import LargeNoDataCard from "../../../components/favourites/LargeNoDataCard";
@@ -23,7 +21,7 @@ const index = () => {
 
   const {
     data: favouritesData,
-    isFetching: isFetchingFavourites,
+    isPending: isFetchingFavourites,
     isFetched: isFetchedFavourites,
     isError: isErrorFavourites,
     error: erroFavourites,
@@ -36,7 +34,7 @@ const index = () => {
 
   const {
     data: recentData,
-    isFetching: isFetchingRecent,
+    isPending: isFetchingRecent,
     isFetched: isFetchedRecent,
     isError: isErrorRecent,
     error: errorRecent,

--- a/SopPro/app/forgot.jsx
+++ b/SopPro/app/forgot.jsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import React, { useState } from "react";
 import { ScrollView } from "react-native-gesture-handler";
 import Header from "../components/UI/Header";

--- a/SopPro/components/sops/VersionCard.jsx
+++ b/SopPro/components/sops/VersionCard.jsx
@@ -6,7 +6,7 @@ import {
   View,
 } from "react-native";
 import React from "react";
-import { getStatus, getStatusColour } from "../../../util/statusHelper";
+import { getStatus, getStatusColour } from "../../util/statusHelper";
 
 const VersionCard = ({
   id,
@@ -20,7 +20,7 @@ const VersionCard = ({
   return (
     <TouchableOpacity
       style={styles.versionCard}
-      onPress={() => handleVersionSelect(id, versionNumber, title)}
+      onPress={() => handleVersionSelect({ id, versionNumber, title })}
     >
       <View style={styles.versionInfo}>
         <Text style={styles.versionTitle}>Version {versionNumber}</Text>

--- a/SopPro/components/sops/bottomSheet/CustomBottomSheetModal.jsx
+++ b/SopPro/components/sops/bottomSheet/CustomBottomSheetModal.jsx
@@ -29,6 +29,7 @@ import {
   Trash2,
   FileCheck2,
   FileDown,
+  History,
 } from "lucide-react-native";
 import VersionPickerModal from "../exportModal/VersionPickerModal";
 import { useBottomSheetBackHandler } from "../../../hooks/useBottomSheetBackHandler";
@@ -48,6 +49,7 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
 
   const { handleSheetPositionChange } = useBottomSheetBackHandler(ref);
   const [exportModalVisibile, setExportModalVisible] = useState(false);
+  const [revertModalVisible, setRevertModalVisible] = useState(false);
   const [confirmationModal, setConfirmationModal] = useState({
     visible: false,
     title: "",
@@ -286,6 +288,11 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
     setExportModalVisible(true);
   }
 
+  function handleRevertPress() {
+    closeSheet();
+    setRevertModalVisible(true);
+  }
+
   const userOptions = [
     {
       key: 1,
@@ -341,6 +348,13 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
     },
     {
       key: 3,
+      title: "Revert version",
+      icon: History,
+      onPress: handleRevertPress,
+      visible: true,
+    },
+    {
+      key: 4,
       title: "Delete",
       icon: Trash2,
       onPress: handleDeletePress,
@@ -423,6 +437,25 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
           isSuccessful={isDownloadSuccessful}
           isError={isDownloadError}
           isDownloading={isDownloading}
+          successMessage="Download successful! ✅"
+          errorMessage="An error occured, download failed."
+          onDismiss={resetDownloadState}
+        />
+      )}
+
+      {revertModalVisible && (
+        <VersionPickerModal
+          sopVersions={sopVersions}
+          visible={revertModalVisible}
+          setVisibility={setRevertModalVisible}
+          onPress={() => {
+            console.log("pressed");
+          }}
+          title="Revert to a previous version"
+          subtitle="Select a version to revert to"
+          isSuccessful={false}
+          isError={false}
+          isDownloading={false}
           successMessage="Download successful! ✅"
           errorMessage="An error occured, download failed."
           onDismiss={resetDownloadState}

--- a/SopPro/components/sops/bottomSheet/CustomBottomSheetModal.jsx
+++ b/SopPro/components/sops/bottomSheet/CustomBottomSheetModal.jsx
@@ -31,11 +31,11 @@ import {
   FileDown,
   History,
 } from "lucide-react-native";
-import VersionPickerModal from "../exportModal/VersionPickerModal";
 import { useBottomSheetBackHandler } from "../../../hooks/useBottomSheetBackHandler";
 import { ScrollView } from "react-native-gesture-handler";
 import ConfirmationModal from "../../UI/ConfirmationModal";
-import useDownload from "../../../hooks/useDownload";
+import ExportModal from "../modals/ExportModal";
+import RevertModal from "../modals/RevertModal";
 
 const CustomBottomSheetModal = forwardRef((props, ref) => {
   const router = useRouter();
@@ -57,14 +57,6 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
     onCancel: () => {},
     onConfirm: () => {},
   });
-
-  const {
-    isDownloading,
-    isSuccessful: isDownloadSuccessful,
-    isError: isDownloadError,
-    handleDownload,
-    resetState: resetDownloadState,
-  } = useDownload();
 
   function closeSheet() {
     ref.current?.close();
@@ -293,6 +285,8 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
     setRevertModalVisible(true);
   }
 
+  function handleRevert({ id, version }) {}
+
   const userOptions = [
     {
       key: 1,
@@ -427,38 +421,18 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
       </BottomSheetModal>
 
       {exportModalVisibile && (
-        <VersionPickerModal
+        <ExportModal
           sopVersions={sopVersions}
           visible={exportModalVisibile}
           setVisibility={setExportModalVisible}
-          onPress={handleDownload}
-          title="Export to PDF"
-          subtitle="Select a version to export"
-          isSuccessful={isDownloadSuccessful}
-          isError={isDownloadError}
-          isDownloading={isDownloading}
-          successMessage="Download successful! ✅"
-          errorMessage="An error occured, download failed."
-          onDismiss={resetDownloadState}
         />
       )}
 
       {revertModalVisible && (
-        <VersionPickerModal
+        <RevertModal
           sopVersions={sopVersions}
           visible={revertModalVisible}
           setVisibility={setRevertModalVisible}
-          onPress={() => {
-            console.log("pressed");
-          }}
-          title="Revert to a previous version"
-          subtitle="Select a version to revert to"
-          isSuccessful={false}
-          isError={false}
-          isDownloading={false}
-          successMessage="Download successful! ✅"
-          errorMessage="An error occured, download failed."
-          onDismiss={resetDownloadState}
         />
       )}
 

--- a/SopPro/components/sops/bottomSheet/CustomBottomSheetModal.jsx
+++ b/SopPro/components/sops/bottomSheet/CustomBottomSheetModal.jsx
@@ -30,10 +30,11 @@ import {
   FileCheck2,
   FileDown,
 } from "lucide-react-native";
-import ExportModal from "../exportModal/ExportModal";
+import VersionPickerModal from "../exportModal/VersionPickerModal";
 import { useBottomSheetBackHandler } from "../../../hooks/useBottomSheetBackHandler";
 import { ScrollView } from "react-native-gesture-handler";
 import ConfirmationModal from "../../UI/ConfirmationModal";
+import useDownload from "../../../hooks/useDownload";
 
 const CustomBottomSheetModal = forwardRef((props, ref) => {
   const router = useRouter();
@@ -54,6 +55,14 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
     onCancel: () => {},
     onConfirm: () => {},
   });
+
+  const {
+    isDownloading,
+    isSuccessful: isDownloadSuccessful,
+    isError: isDownloadError,
+    handleDownload,
+    resetState: resetDownloadState,
+  } = useDownload();
 
   function closeSheet() {
     ref.current?.close();
@@ -404,10 +413,19 @@ const CustomBottomSheetModal = forwardRef((props, ref) => {
       </BottomSheetModal>
 
       {exportModalVisibile && (
-        <ExportModal
+        <VersionPickerModal
           sopVersions={sopVersions}
           visible={exportModalVisibile}
           setVisibility={setExportModalVisible}
+          onPress={handleDownload}
+          title="Export to PDF"
+          subtitle="Select a version to export"
+          isSuccessful={isDownloadSuccessful}
+          isError={isDownloadError}
+          isDownloading={isDownloading}
+          successMessage="Download successful! ✅"
+          errorMessage="An error occured, download failed."
+          onDismiss={resetDownloadState}
         />
       )}
 

--- a/SopPro/components/sops/exportModal/VersionPickerModal.jsx
+++ b/SopPro/components/sops/exportModal/VersionPickerModal.jsx
@@ -4,32 +4,27 @@ import { ActivityIndicator, Button, Modal, Portal } from "react-native-paper";
 import VersionCard from "./VersionCard";
 import { downloadSopVersion } from "../../../util/downloadHelper";
 import ErrorBlock from "../../UI/ErrorBlock";
+import useDownload from "../../../hooks/useDownload";
 
-const ExportModal = ({ sopVersions, visible, setVisibility }) => {
-  const [isDownloading, setIsDownloading] = useState(false);
-  const [isSuccessful, setIsSuccessful] = useState(false);
-  const [isError, setIsError] = useState(false);
+const VersionPickerModal = ({
+  sopVersions,
+  title,
+  subtitle,
+  visible,
+  setVisibility,
+  onPress,
+  isSuccessful,
+  isError,
+  successMessage,
+  errorMessage,
+  isDownloading,
+  onDismiss,
+}) => {
+  const successText = <Text style={styles.successText}>{successMessage}</Text>;
 
-  async function handleDownload(versionId, reference, title) {
-    setIsDownloading(true);
-    setIsSuccessful(false);
-    setIsError(false);
-    try {
-      await downloadSopVersion(versionId, reference, title);
-      setIsSuccessful(true);
-    } catch (e) {
-      setIsError(true);
-    }
-    setIsDownloading(false);
-  }
-
-  const successMessage = (
-    <Text style={styles.successText}>Download successful! ✅</Text>
-  );
-
-  const errorMessage = (
+  const errorText = (
     <ErrorBlock>
-      <Text>An error occured, download failed.</Text>
+      <Text>{errorMessage}</Text>
     </ErrorBlock>
   );
 
@@ -38,14 +33,17 @@ const ExportModal = ({ sopVersions, visible, setVisibility }) => {
       <Modal
         visible={visible}
         contentContainerStyle={styles.modalContainer}
-        onDismiss={() => setVisibility(false)}
+        onDismiss={() => {
+          onDismiss && onDismiss();
+          setVisibility(false);
+        }}
       >
         <View style={styles.exportContainer}>
           {isDownloading && <ActivityIndicator />}
-          {isError && errorMessage}
-          {isSuccessful && successMessage}
-          <Text style={styles.exportTitle}>Export to PDF</Text>
-          <Text style={styles.exportSubtitle}>Select a version to export</Text>
+          {isError && errorText}
+          {isSuccessful && successText}
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.subtitle}>{subtitle}</Text>
 
           <ScrollView style={styles.versionsContainer}>
             {sopVersions?.map((version) => {
@@ -57,7 +55,7 @@ const ExportModal = ({ sopVersions, visible, setVisibility }) => {
                   createDate={version.createDate}
                   status={version.status}
                   title={version.title}
-                  handleVersionSelect={handleDownload}
+                  handleVersionSelect={onPress}
                 />
               );
             })}
@@ -68,7 +66,7 @@ const ExportModal = ({ sopVersions, visible, setVisibility }) => {
   );
 };
 
-export default ExportModal;
+export default VersionPickerModal;
 
 const styles = StyleSheet.create({
   modalContainer: {
@@ -83,12 +81,12 @@ const styles = StyleSheet.create({
   versionsContainer: {
     flex: 1,
   },
-  exportTitle: {
+  title: {
     fontSize: 20,
     fontWeight: "bold",
     marginBottom: 8,
   },
-  exportSubtitle: {
+  subtitle: {
     fontSize: 14,
     color: "#666",
     marginBottom: 16,

--- a/SopPro/components/sops/modals/ExportModal.jsx
+++ b/SopPro/components/sops/modals/ExportModal.jsx
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from "react-native";
+import React from "react";
+import VersionPickerModal from "./VersionPickerModal";
+import useDownload from "../../../hooks/useDownload";
+
+const ExportModal = ({ sopVersions, visible, setVisibility }) => {
+  const {
+    isDownloading,
+    isSuccessful: isDownloadSuccessful,
+    isError: isDownloadError,
+    handleDownload,
+  } = useDownload();
+
+  return (
+    <VersionPickerModal
+      sopVersions={sopVersions}
+      visible={visible}
+      setVisibility={setVisibility}
+      onPress={handleDownload}
+      title="Export to PDF"
+      subtitle="Select a version to export"
+      isSuccessful={isDownloadSuccessful}
+      isError={isDownloadError}
+      isDownloading={isDownloading}
+      successMessage="Download successful! ✅"
+      errorMessage="An error occured, download failed."
+    />
+  );
+};
+
+export default ExportModal;
+
+const styles = StyleSheet.create({});

--- a/SopPro/components/sops/modals/ExportModal.jsx
+++ b/SopPro/components/sops/modals/ExportModal.jsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet } from "react-native";
 import React from "react";
 import VersionPickerModal from "./VersionPickerModal";
 import useDownload from "../../../hooks/useDownload";

--- a/SopPro/components/sops/modals/RevertModal.jsx
+++ b/SopPro/components/sops/modals/RevertModal.jsx
@@ -1,0 +1,38 @@
+import { StyleSheet, Text, View } from "react-native";
+import React from "react";
+import VersionPickerModal from "./VersionPickerModal";
+import useDownload from "../../../hooks/useDownload";
+import { useMutation } from "@tanstack/react-query";
+import { revertSopVersion } from "../../../util/httpRequests";
+
+const RevertModal = ({ sopVersions, visible, setVisibility }) => {
+  const { mutate, isSuccess, isPending, isError } = useMutation({
+    mutationFn: revertSopVersion,
+    onSuccess: () => {},
+    onError: (error) => {},
+  });
+
+  function handleRevert({ id }) {
+    mutate({ versionId: id });
+  }
+
+  return (
+    <VersionPickerModal
+      sopVersions={sopVersions}
+      visible={visible}
+      setVisibility={setVisibility}
+      onPress={handleRevert}
+      title="Revert to a previous version"
+      subtitle="Select a version to revert to"
+      isSuccessful={isSuccess}
+      isError={isError}
+      isDownloading={isPending}
+      successMessage="Success! Reverted to the specified version ✅"
+      errorMessage="An error occured, download failed."
+    />
+  );
+};
+
+export default RevertModal;
+
+const styles = StyleSheet.create({});

--- a/SopPro/components/sops/modals/RevertModal.jsx
+++ b/SopPro/components/sops/modals/RevertModal.jsx
@@ -2,14 +2,33 @@ import { StyleSheet, Text, View } from "react-native";
 import React from "react";
 import VersionPickerModal from "./VersionPickerModal";
 import useDownload from "../../../hooks/useDownload";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { revertSopVersion } from "../../../util/httpRequests";
+import { QueryClient } from "@tanstack/react-query";
+import Toast from "react-native-toast-message";
 
 const RevertModal = ({ sopVersions, visible, setVisibility }) => {
+  const queryClient = useQueryClient();
   const { mutate, isSuccess, isPending, isError } = useMutation({
     mutationFn: revertSopVersion,
-    onSuccess: () => {},
-    onError: (error) => {},
+    onSuccess: () => {
+      queryClient.invalidateQueries(["sops"]);
+      setVisibility(false);
+      Toast.show({
+        type: "success",
+        text1: "Success",
+        text2: "SOP Successfully reverted",
+        visibilityTime: 3000,
+      });
+    },
+    onError: (error) => {
+      Toast.show({
+        type: "error",
+        text1: "Error",
+        text2: error.message,
+        visibilityTime: 5000,
+      });
+    },
   });
 
   function handleRevert({ id }) {

--- a/SopPro/components/sops/modals/RevertModal.jsx
+++ b/SopPro/components/sops/modals/RevertModal.jsx
@@ -1,14 +1,17 @@
-import { StyleSheet, Text, View } from "react-native";
-import React from "react";
+import { StyleSheet } from "react-native";
+import React, { useState } from "react";
 import VersionPickerModal from "./VersionPickerModal";
-import useDownload from "../../../hooks/useDownload";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { revertSopVersion } from "../../../util/httpRequests";
-import { QueryClient } from "@tanstack/react-query";
 import Toast from "react-native-toast-message";
+import ConfirmationModal from "../../UI/ConfirmationModal";
 
 const RevertModal = ({ sopVersions, visible, setVisibility }) => {
   const queryClient = useQueryClient();
+  const [isConfirmationModalVisible, setIsConfirmationModalVisible] =
+    useState(false);
+  const [selectedId, setSelectedId] = useState(null);
+
   const { mutate, isSuccess, isPending, isError } = useMutation({
     mutationFn: revertSopVersion,
     onSuccess: () => {
@@ -22,6 +25,7 @@ const RevertModal = ({ sopVersions, visible, setVisibility }) => {
       });
     },
     onError: (error) => {
+      setVisibility(false);
       Toast.show({
         type: "error",
         text1: "Error",
@@ -32,23 +36,40 @@ const RevertModal = ({ sopVersions, visible, setVisibility }) => {
   });
 
   function handleRevert({ id }) {
-    mutate({ versionId: id });
+    setIsConfirmationModalVisible(true);
+    setSelectedId(id);
+  }
+
+  function handleConfirmRevert() {
+    mutate({ versionId: selectedId });
+    setIsConfirmationModalVisible(false);
+    setSelectedId(null);
   }
 
   return (
-    <VersionPickerModal
-      sopVersions={sopVersions}
-      visible={visible}
-      setVisibility={setVisibility}
-      onPress={handleRevert}
-      title="Revert to a previous version"
-      subtitle="Select a version to revert to"
-      isSuccessful={isSuccess}
-      isError={isError}
-      isDownloading={isPending}
-      successMessage="Success! Reverted to the specified version ✅"
-      errorMessage="An error occured, download failed."
-    />
+    <>
+      <VersionPickerModal
+        sopVersions={sopVersions}
+        visible={visible}
+        setVisibility={setVisibility}
+        onPress={handleRevert}
+        title="Revert to a previous version"
+        subtitle="Select a version to revert to"
+        isSuccessful={isSuccess}
+        isError={isError}
+        isDownloading={isPending}
+        successMessage="Success! Reverted to the specified version ✅"
+        errorMessage="An error occured"
+      />
+
+      <ConfirmationModal
+        visible={isConfirmationModalVisible}
+        onConfirm={handleConfirmRevert}
+        onCancel={() => setIsConfirmationModalVisible(false)}
+        title="Confirm version revertion"
+        subtitle="This cannot be undone. Any versions after the selected version will be permenantly deleted"
+      />
+    </>
   );
 };
 

--- a/SopPro/components/sops/modals/VersionPickerModal.jsx
+++ b/SopPro/components/sops/modals/VersionPickerModal.jsx
@@ -1,10 +1,8 @@
 import { ScrollView, StyleSheet, Text, View } from "react-native";
-import React, { useState } from "react";
+import React from "react";
 import { ActivityIndicator, Button, Modal, Portal } from "react-native-paper";
-import VersionCard from "./VersionCard";
-import { downloadSopVersion } from "../../../util/downloadHelper";
+import VersionCard from "../VersionCard";
 import ErrorBlock from "../../UI/ErrorBlock";
-import useDownload from "../../../hooks/useDownload";
 
 const VersionPickerModal = ({
   sopVersions,
@@ -18,7 +16,6 @@ const VersionPickerModal = ({
   successMessage,
   errorMessage,
   isDownloading,
-  onDismiss,
 }) => {
   const successText = <Text style={styles.successText}>{successMessage}</Text>;
 
@@ -34,7 +31,6 @@ const VersionPickerModal = ({
         visible={visible}
         contentContainerStyle={styles.modalContainer}
         onDismiss={() => {
-          onDismiss && onDismiss();
           setVisibility(false);
         }}
       >

--- a/SopPro/hooks/useDownload.js
+++ b/SopPro/hooks/useDownload.js
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { downloadSopVersion } from "../util/downloadHelper";
+
+export default downloadSop = () => {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [isSuccessful, setIsSuccessful] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  function resetState() {
+    setIsDownloading(false);
+    setIsSuccessful(false);
+    setIsError(false);
+  }
+
+  const handleDownload = async (versionId, reference, title) => {
+    setIsDownloading(true);
+    setIsSuccessful(false);
+    setIsError(false);
+
+    try {
+      await downloadSopVersion(versionId, reference, title);
+      setIsSuccessful(true);
+    } catch (e) {
+      setIsError(true);
+    }
+    setIsDownloading(false);
+  };
+
+  return {
+    isDownloading,
+    isSuccessful,
+    isError,
+    handleDownload,
+    resetState,
+  };
+};

--- a/SopPro/hooks/useDownload.js
+++ b/SopPro/hooks/useDownload.js
@@ -6,19 +6,13 @@ export default downloadSop = () => {
   const [isSuccessful, setIsSuccessful] = useState(false);
   const [isError, setIsError] = useState(false);
 
-  function resetState() {
-    setIsDownloading(false);
-    setIsSuccessful(false);
-    setIsError(false);
-  }
-
-  const handleDownload = async (versionId, reference, title) => {
+  const handleDownload = async ({ id, reference, title }) => {
     setIsDownloading(true);
     setIsSuccessful(false);
     setIsError(false);
 
     try {
-      await downloadSopVersion(versionId, reference, title);
+      await downloadSopVersion(id, reference, title);
       setIsSuccessful(true);
     } catch (e) {
       setIsError(true);
@@ -31,6 +25,5 @@ export default downloadSop = () => {
     isSuccessful,
     isError,
     handleDownload,
-    resetState,
   };
 };

--- a/SopPro/util/httpRequests.js
+++ b/SopPro/util/httpRequests.js
@@ -1,3 +1,4 @@
+import { version } from "react";
 import api from "../api/axiosApi";
 
 export async function registerCompany(data) {
@@ -178,6 +179,19 @@ export async function deleteSops(ids) {
   } catch (e) {
     const error = new Error(
       e.response?.data?.errorMessage || "Error deleting SOPs"
+    );
+    throw error;
+  }
+}
+
+export async function revertSopVersion({ versionId }) {
+  const data = { versionId };
+  try {
+    const response = await api.post("/sop/revert", data);
+    return response.data;
+  } catch (e) {
+    const error = new Error(
+      e.response?.data?.errorMessage || "Error reverting version"
     );
     throw error;
   }


### PR DESCRIPTION
### Summary
- Added a new feature to allow administrators to revert a SOP to a previous version
- Refactored the ExportModal to produce a VersionPickerModal which is reused for Exporting and for Reverting (where a list of versions is displayed for selection)
- Displayed a confirmation modal to warn users of the deletion of later versions
- Added backend controller and service logic to revert the SOP
- Fixed a UX issue on the home tab where results appeared to flicker when refetching data after the cached data was invalidated.
- Wrote a custom hook for handling downloads (useDownload)
- Handled success and error scenarios during reverting
![Feb-22-2025 19-09-03](https://github.com/user-attachments/assets/361c53ff-2179-4825-a104-b4489e7e06e0)


