### PR TITLE
Failed login attempts lockout

### DIFF
--- a/Backend/Backend/Controllers/AuthController.cs
+++ b/Backend/Backend/Controllers/AuthController.cs
@@ -26,7 +26,7 @@ namespace Backend.Controllers
         {
             var apiResponse = await _authService.Login(model, ModelState);
 
-            return Ok(apiResponse);
+            return StatusCode((int)apiResponse.StatusCode, apiResponse);
         }
 
         [HttpPost("signuporganisation")]

--- a/Backend/Backend/Program.cs
+++ b/Backend/Backend/Program.cs
@@ -43,6 +43,11 @@ builder.Services.Configure<IdentityOptions>(options =>
     options.Password.RequireUppercase = true;
     options.Password.RequiredLength = 8;
     options.Password.RequiredUniqueChars = 1;
+
+    // lockout options
+    options.Lockout.AllowedForNewUsers = true;
+    options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
+    options.Lockout.MaxFailedAccessAttempts = 5;
 });
 
 var key = builder.Configuration.GetValue<string>("ApplicationSettings:JwtSecret");

--- a/SopPro/components/UI/ErrorBlock.jsx
+++ b/SopPro/components/UI/ErrorBlock.jsx
@@ -25,8 +25,11 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#ad3137",
     borderRadius: 8,
+    maxWidth: "100%",
   },
   text: {
+    flexShrink: 1,
     color: "#ad3137",
+    flexWrap: "wrap",
   },
 });


### PR DESCRIPTION
### Summary
- Add backend logic to lock out users after 5 failed login attempts for 5 minutes, to reduce the risk of brute force security breaches.
- Fix bug on error block component where text was overflowing.


<img width="380" alt="Screenshot 2025-02-23 at 11 24 25" src="https://github.com/user-attachments/assets/c879b799-d5d9-490f-8f9f-03cba5fe1b0c" />
