### PR TITLE
Fix bug where loading spinner was displayed when isCreate was true

### DIFF
--- a/SopPro/app/(auth)/(admin)/department/[id].jsx
+++ b/SopPro/app/(auth)/(admin)/department/[id].jsx
@@ -79,9 +79,8 @@ const Upsert = () => {
       });
     },
   });
-
   const { data, isPending, isError, error } = useQuery({
-    enabled: id != -1,
+    enabled: isCreate == false,
     queryKey: ["departments", id],
     queryFn: () => fetchDepartment(id),
   });
@@ -120,7 +119,7 @@ const Upsert = () => {
     setModalVisisble(false);
   }
 
-  if (isPending) {
+  if (!isCreate && isPending) {
     return (
       <View style={styles.loader}>
         <ActivityIndicator animating={true} />


### PR DESCRIPTION
### Summary
- Fixed a bug which caused the loading spinner to show instead of the "Create" form when rendering the "Create" new department screen/form.

The issue was even though the query was disabled when isCreate is true, react query still initialises isPending to true which was being used to display the spinner. Added additional check to check that isCreate is false and isPending is true before rendering the spinner.