### PR TITLE
Explicitly include templates folder for deployment

### DIFF
--- a/Backend/Backend/Backend.csproj
+++ b/Backend/Backend/Backend.csproj
@@ -26,4 +26,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Templates\**" CopyToPublishDirectory="Always" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixed an issue where the email templates folder was not being included in the azure deployment, leading to an exception on some functionality where emails were being sent